### PR TITLE
Add BinaryQuickSave Option

### DIFF
--- a/zUtilities/Options.h
+++ b/zUtilities/Options.h
@@ -54,7 +54,8 @@ namespace GOTHIC_ENGINE {
       zoptions->AddTrivia( PLUGIN_NAME, "KeyTimeMultiplier", "... key for cycling time speed" );
       zoptions->AddTrivia( PLUGIN_NAME, "TimeMultipliers", "... defines time multipliers" );
 
-      zoptions->AddTrivia( PLUGIN_NAME, "UseQuickSave", "... enables (1) or disables (0) QuickSaving with [F10] and QuickLoading with [F12]" );
+      zoptions->AddTrivia( PLUGIN_NAME, "UseQuickSave", "... enables (1) or disables (0) QuickSaving with [F10] and QuickLoading with [F12]");
+      zoptions->AddTrivia( PLUGIN_NAME, "UseBinarySave", "... enables (1) or disables (0) Binary saving, that helps to save bigger span of gameplay");
       zoptions->AddTrivia( PLUGIN_NAME, "KeyQuickSave", "... key for QuickSave" );
       zoptions->AddTrivia( PLUGIN_NAME, "KeyQuickLoad", "... key for QuickLoad" );
       zoptions->AddTrivia( PLUGIN_NAME, "MinSaveSlot", "... defines min range of used save slots" );

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -7,19 +7,25 @@ namespace GOTHIC_ENGINE {
 
     int latestNr = 0;
     int latestSaveSlot = Invalid;
+    
 
-    for ( int i = 0; i < saveList.GetNum(); i++ ) {
-      if ( saveList[i]->m_SlotNr < Options::MinSaveSlot || saveList[i]->m_SlotNr > Options::MaxSaveSlot )
-        continue;
+    if ( UseQuickSave ) {
 
-      if ( !saveList[i]->GetName().HasWord( Options::SaveName ) )
-        continue;
+    }
+    else {
+        for ( int i = 0; i < saveList.GetNum(); i++ ) {
+            if ( saveList[i]->m_SlotNr < Options::MinSaveSlot || saveList[i]->m_SlotNr > Options::MaxSaveSlot )
+                continue;
 
-      int nr = saveList[i]->GetName().Cut( 0, Options::SaveName.Length() ).ToInt32();
-      if ( nr > latestNr ) {
-        latestNr = nr;
-        latestSaveSlot = saveList[i]->m_SlotNr;
-      }
+            if ( !saveList[i]->GetName().HasWord( Options::SaveName ) )
+                continue;
+
+            int nr = saveList[i]->GetName().Cut( 0, Options::SaveName.Length() ).ToInt32();
+            if ( nr > latestNr ) {
+                latestNr = nr;
+                latestSaveSlot = saveList[i]->m_SlotNr;
+            }
+        }
     }
 
     iLastSaveNumber = latestNr;

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -7,9 +7,16 @@ namespace GOTHIC_ENGINE {
 
     int latestNr = 0;
     int latestSaveSlot = Invalid;
-    
 
-    if ( UseQuickSave ) {
+    if ( Options::UseQuickSave ) {
+
+        int slotIndicies[1024] = { 0 }; // safe buffer for saveSlots
+        int slotNames[1024] = { 0 };
+        int length = 0;
+        int maxName = -1; // initialize with negative, so we get a slotName = 0 with correct index
+        int maxNameIndex = -1;
+
+
         // The algorithm looks very like adding numbers in binary.
         // The idea behind using a binary addition is too use some SaveSlots
         // more frequently then others. for example:
@@ -46,6 +53,32 @@ namespace GOTHIC_ENGINE {
         // The problem in implementing that, is to create a naming system that
         // can determine the Spot to Save, at any give point in time.
         // Even after exit/restart of the game.
+
+        for ( int i = 0; i < saveList.GetNum(); i++ ) {
+            if ( saveList[i]->m_SlotNr < Options::MinSaveSlot || saveList[i]->m_SlotNr > Options::MaxSaveSlot )
+                continue;
+            // XXX: does m_slotNr is a increesing value for SaveSlots
+            //      do I need to use a for loop, or can I just use MinSaveSlot and MaxSaveSlot for knowing the available slotNumbers?
+            slotIndicies[i] = saveList[i]->m_SlotNr;
+            slotNames[i] = saveList[i]->GetName().Cut( 0, Options::SaveName.Length() ).ToInt32()
+            length++;
+            if (slotNames[i] > maxName ) {
+                maxName = slotNames[i];
+                maxNameIndex = slotIndicies[i];
+            }
+        }
+
+        // we had some slots to save on, but we did not found a slot already saved.
+        // We are saving for the first time probably
+        if ( length > 0 && maxNameIndex < 0 ) {
+            latestNr = 0; 
+            latestSaveSlots = slotIndicies[0]; // use first available slot (will be MinSaveSlot)
+        }
+        // we had some slots to save on, and we found flot with existing save.
+        // now we need to figure out, on which slot to put next save.
+        else if ( length > 0 ) {
+
+        }
     }
     else {
         for ( int i = 0; i < saveList.GetNum(); i++ ) {

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -59,7 +59,7 @@ namespace GOTHIC_ENGINE {
       return;
     }
 
-    if ( Options::UseQuickSave ) {
+    if ( Options::UseBinarySave ) {
         // The algorithm looks very like adding numbers in binary.
         // The idea behind using a binary addition is too use some SaveSlots
         // more frequently then others. for example:
@@ -100,19 +100,19 @@ namespace GOTHIC_ENGINE {
         // We are saving for the first time probably
         if ( iLastSaveNumber == Invalid) {
             iLastSaveSlot = Options::MinSaveSlot;
-            iLastSaveNumber = 1; // I could use ZERO as a first SaveName, it doesnt matter. number ONE is just more pleasant to the eye
+            iLastSaveNumber = 1; // I could use ZERO as a first SaveName, it doesn't matter. number ONE is just more pleasant to the eye
         }
         // we need to figure out, on which slot to put next save.
         else {
-            iLastSaveNumber++;
-            int const nextName = maxName + 1;
+            int const curName = iLastSaveNumber;
+            int const nextName = curName + 1;
             // Now we need to find a change from 0 -> 1 between maxName and nextName
             int changeIndex = -1;
             int mask = 0x100000; // 10...0
             // XXX: Not sure of `size(int) - 1`, it takes one of the save spots out.
             //      But I am also nervous of checking 2^32 This needs to be tested.
             for ( int i = 0; i < sizeof(int) - 1; ++i) {
-                if ( nextName & mask > maxName & mask ) {
+                if ( nextName & mask > curName & mask ) {
                     changeIndex = i;
                     break;
                 }
@@ -132,6 +132,7 @@ namespace GOTHIC_ENGINE {
                     changeIndex -= slots;
                 }
                 iLastSaveSlot = Options::MinSaveSlot + changeIndex;
+                iLastSaveNumber++;
             }
         }
     }

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -10,7 +10,42 @@ namespace GOTHIC_ENGINE {
     
 
     if ( UseQuickSave ) {
-
+        // The algorithm looks very like adding numbers in binary.
+        // The idea behind using a binary addition is too use some SaveSlots
+        // more frequently then others. for example:
+        // Slot0 -> will be used 50%
+        // Slot1 -> will be used 25%
+        // Slot2 -> will be used 12%
+        // Slot3 -> will be used  6%
+        // Slot4 -> will be used  3%
+        // Slot5 -> will be used  1%
+        // Thanks to that, we have Slot5, Slot4 keeping the oldest (in actual date time) Saves
+        // Whiles Slot0, Slot1, keeping the newest (in actual date time) Saves
+        // This will give the ability to Load old save from Slot5, that was saved (lets say 2 ^ 5 = 32 saves ago)
+        // And at the same time, we have Slot1, Slot2 with newest saves (lets say last save)
+        //
+        // Example of such saving, I will mark a SaveSpot with brackets (numbers are an ID of a save):
+        //  -   [1]   1   [3]   3   [5]   5   [7]   7
+        //  -    -   [2]   2    2    2   [6]   6    6
+        //  -    -    -    -   [4]   4    4    4    4
+        //  -    -    -    -    -    -    -    -   [8]
+        //  
+        // And their binary representation (numbers are a binary tree that helps me to determine SaveSpot):
+        //  0   [1]   0   [1]   0   [1]   0   [1]   0
+        //  0    0   [1]   1    0    0   [1]   1    0
+        //  0    0    0    0   [1]   1    1    1    0
+        //  0    0    0    0    0    0    0    0   [1]
+        // 
+        // And their decimal representation:
+        //  0    1    2    3    4    5    6    7    8
+        // 
+        // As you can see, the SaveSpots (brackets), are in a places where the
+        // number changed from 0 -> 1, number changing from 1 -> 0 does not matter.
+        // 
+        // 
+        // The problem in implementing that, is to create a naming system that
+        // can determine the Spot to Save, at any give point in time.
+        // Even after exit/restart of the game.
     }
     else {
         for ( int i = 0; i < saveList.GetNum(); i++ ) {

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -108,24 +108,20 @@ namespace GOTHIC_ENGINE {
             int const nextName = curName + 1;
             // Now we need to find a change from 0 -> 1 between maxName and nextName
             int changeIndex = -1;
-            int mask = 0x100000; // 10...0
-            // XXX: Not sure of `size(int) - 1`, it takes one of the save spots out.
-            //      But I am also nervous of checking 2^32 This needs to be tested.
-            for ( int i = 0; i < sizeof(int) - 1; ++i) {
-                if ( nextName & mask > curName & mask ) {
+            int mask = ((int)1); // 0...01
+            for ( int i = 0; i < (sizeof(int) * 8) - 1; ++i) {
+                if (( nextName & mask ) > ( curName & mask )) {
                     changeIndex = i;
                     break;
                 }
                 // this operation moves 1 to the right, and resets first bit to 0, in order to check next bit
-                mask = (mask > 1) & 0x7FFFFF; // 01...1
+                mask = (mask << 1) & (~((int)1)); // 1...10
             }
 
             if ( changeIndex != -1 ) {
                 // We found an index where change happens, but this index is between 0 and 31.
                 // We need to cap it between Options::MinSaveSlot and Options::MaxSaveSlot
                 // To do it, I will wrap the number system around
-                // 
-                // XXX: depending if MaxSaveSlot count that slot, `slots` will require +1 or +0
                 int const slots = Options::MaxSaveSlot - Options::MinSaveSlot;
                 while ( changeIndex > slots ) {
                     // this operation moves the index one to the left, in order to fit in number of available slots

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -104,13 +104,17 @@ namespace GOTHIC_ENGINE {
         }
         // we need to figure out, on which slot to put next save.
         else {
+            iLastSaveNumber++;
             int nextName = maxName + 1;
             // now we need to find a change from 0 -> 1 between maxName and nextName
             int changeIndex = 0;
             int mask = 0x100000; // 10...0
-            if (nextName & mask > maxName & mask) {
-                latestNr = -1; // TODO
-                latestSaveSlot = -1; // TODO
+            for ( int i = 0; i < sizeof(int) - 1; ++i) {
+                if (nextName & mask > maxName & mask) {
+                    iLastSaveSlot = i; // TODO
+                    break;
+                }
+                mask = (mask > 1) & 0x7FFFFF; // 01...1
             }
         }
     }

--- a/zUtilities/QuickSave.h
+++ b/zUtilities/QuickSave.h
@@ -7,8 +7,8 @@ namespace GOTHIC_ENGINE {
     string CantSave, CantLoad, NoSave, SaveName;
 
     void QuickSave() {
-        UseQuickSave = zoptions->ReadBool(PLUGIN_NAME, "UseQuickSave", true );
-        UseBinarySave = zoptions->ReadBool(PLUGIN_NAME, "UseBinarySave", false );
+        UseQuickSave = zoptions->ReadBool( PLUGIN_NAME, "UseQuickSave", true );
+        UseBinarySave = zoptions->ReadBool( PLUGIN_NAME, "UseBinarySave", false );
 
       KeyQuickSave = GetEmulationKeyCode( zoptions->ReadString( PLUGIN_NAME, "KeyQuickSave", "KEY_F10" ) );
       KeyQuickLoad = GetEmulationKeyCode( zoptions->ReadString( PLUGIN_NAME, "KeyQuickLoad", "KEY_F12" ) );

--- a/zUtilities/QuickSave.h
+++ b/zUtilities/QuickSave.h
@@ -3,11 +3,12 @@
 
 namespace GOTHIC_ENGINE {
   namespace Options {
-    int UseQuickSave, KeyQuickSave, KeyQuickLoad, MinSaveSlot, MaxSaveSlot;
+    int UseQuickSave, UseBinarySave, KeyQuickSave, KeyQuickLoad, MinSaveSlot, MaxSaveSlot;
     string CantSave, CantLoad, NoSave, SaveName;
 
     void QuickSave() {
-      UseQuickSave = zoptions->ReadBool( PLUGIN_NAME, "UseQuickSave", true );
+        UseQuickSave = zoptions->ReadBool(PLUGIN_NAME, "UseQuickSave", true );
+        UseBinarySave = zoptions->ReadBool(PLUGIN_NAME, "UseBinarySave", false );
 
       KeyQuickSave = GetEmulationKeyCode( zoptions->ReadString( PLUGIN_NAME, "KeyQuickSave", "KEY_F10" ) );
       KeyQuickLoad = GetEmulationKeyCode( zoptions->ReadString( PLUGIN_NAME, "KeyQuickLoad", "KEY_F12" ) );

--- a/zUtilities/zUtilities.vcxproj
+++ b/zUtilities/zUtilities.vcxproj
@@ -387,8 +387,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -412,8 +411,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -437,8 +435,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -462,8 +459,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -487,8 +483,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -512,8 +507,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -541,8 +535,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -570,8 +563,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -599,8 +591,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -628,8 +619,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -657,8 +647,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -686,8 +675,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -715,8 +703,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -744,8 +731,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -773,8 +759,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -802,8 +787,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -831,8 +815,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -860,8 +843,7 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>
-      </Command>
+      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>

--- a/zUtilities/zUtilities.vcxproj
+++ b/zUtilities/zUtilities.vcxproj
@@ -387,7 +387,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -411,7 +412,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -435,7 +437,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -459,7 +462,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -483,7 +487,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -507,7 +512,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -535,7 +541,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -563,7 +570,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -591,7 +599,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -619,7 +628,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -647,7 +657,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -675,7 +686,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -703,7 +715,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -731,7 +744,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -759,7 +773,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -787,7 +802,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -815,7 +831,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -843,7 +860,8 @@
       <ProgramDatabaseFile>$(SolutionDir)PDB\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Build\beforebuild.exe $(SolutionDir)</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>


### PR DESCRIPTION
Binary saving helps to preserve older save games, while allowing for a frequent saving. If you dedicate 10 slots for saving, it will save 1024 times in a binary theme. The lower save slots will be saved more frequent, then higher save slots. 