### PR TITLE
Munition dangled pointer fix

### DIFF
--- a/zUtilities/Inventory.cpp
+++ b/zUtilities/Inventory.cpp
@@ -35,6 +35,9 @@ namespace GOTHIC_ENGINE {
     if ( !Options::ActivateUsedMunition )
       return;
 
+    if (!player->inventory2.IsOpen())
+        return;
+
     if (lastActiveMunition) {
         if (player->inventory2.IsIn(lastActiveMunition, 1) == nullptr
             && player->GetLeftHand() != lastActiveMunition
@@ -47,9 +50,6 @@ namespace GOTHIC_ENGINE {
       HandleMunition( nullptr );
       return;
     }
-
-    if ( !player->inventory2.IsOpen() )
-      return;
 
     oCItem* weapon = player->GetEquippedRangedWeapon();
 

--- a/zUtilities/Inventory.cpp
+++ b/zUtilities/Inventory.cpp
@@ -35,6 +35,14 @@ namespace GOTHIC_ENGINE {
     if ( !Options::ActivateUsedMunition )
       return;
 
+    if (lastActiveMunition) {
+        if (player->inventory2.IsIn(lastActiveMunition, 1) == nullptr
+            && player->GetLeftHand() != lastActiveMunition
+            && player->GetRightHand() != lastActiveMunition) {
+            lastActiveMunition = nullptr;
+        }
+    }
+
     if ( playerStatus.traderNpc ) {
       HandleMunition( nullptr );
       return;


### PR DESCRIPTION
You store munition in a global pointer, but do not check whether that pointer is valid, 
which may lead to deleted memory access and UB, e.g. if munition is removed from the world. 
I also did a little condition optimization.

As you can see in this screenshot, there may have been a situation where the flag of a random item in the world was changed.
And in the worst case, there would be a crash.
![ub](https://github.com/Franisz/zUtilities/assets/30447446/2e57395d-31f2-4378-8912-4c57c0eaa68a)
