### PR TITLE
Added ability to load game from Main Menu

### DIFF
--- a/zUtilities/Plugin.cpp
+++ b/zUtilities/Plugin.cpp
@@ -31,6 +31,7 @@ namespace GOTHIC_ENGINE {
   }
 
   void Game_MenuLoop() {
+    quickSave->MenuLoop();
   }
 
   // Information about current saving or loading world

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -236,14 +236,25 @@ namespace GOTHIC_ENGINE {
   }
 
   void QuickSave::MenuLoop() {
-    if ( !Options::QuickSaveMode ) return;
+    if ( !Options::QuickSaveMode || zCMenu::inGameMenu ) return;
 
-    if ( !zinput->KeyToggled(Options::KeyQuickLoad) ) return;
+    if ( keepClosingMenus ) {
+      CloseMenuIfNotMain();
+      return;
+    }
+
+    if ( zinput->KeyToggled( Options::KeyQuickLoad ) ) {
+      keepClosingMenus = true;
+      keyQuickLoadPressed = true;
+    }
+
+    if ( !( keyQuickLoadPressed && !keepClosingMenus ) ) return;
+    keyQuickLoadPressed = false;
 
     auto menu = zCMenu::GetActive();
-    if ( !menu || menu->inGameMenu ) return;
+    if ( !menu ) return;
 
-    oCSavegameInfo* info = gameMan->savegameManager->GetSavegame(iLastSaveSlot);
+    oCSavegameInfo* info = gameMan->savegameManager->GetSavegame( iLastSaveSlot );
     if ( !info || !info->DoesSavegameExist() ) return;
 
     menu->m_exitState = zCMenu::BACK;
@@ -256,6 +267,17 @@ namespace GOTHIC_ENGINE {
 #else
     gameMan->Read_Savegame( info->m_SlotNr );
 #endif
+  }
+
+  void QuickSave::CloseMenuIfNotMain() {
+    auto menu = zCMenu::GetActive();
+
+    if ( menu && menu->name != "MENU_MAIN" ) {
+      menu->m_exitState = zCMenu::BACK;
+    }
+    else {
+      keepClosingMenus = false;
+    }
   }
 
   QuickSave::QuickSave() {

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -235,6 +235,29 @@ namespace GOTHIC_ENGINE {
     CheckSave();
   }
 
+  void QuickSave::MenuLoop() {
+    if ( !Options::QuickSaveMode ) return;
+
+    if ( !zinput->KeyToggled(Options::KeyQuickLoad) ) return;
+
+    auto menu = zCMenu::GetActive();
+    if ( !menu || menu->inGameMenu ) return;
+
+    oCSavegameInfo* info = gameMan->savegameManager->GetSavegame(iLastSaveSlot);
+    if ( !info || !info->DoesSavegameExist() ) return;
+
+    menu->m_exitState = zCMenu::BACK;
+    gameMan->menu_load_savegame->m_selSlot = iLastSaveSlot;
+
+    isLoading = true;
+    StartSaveLoad();
+#if ENGINE == Engine_G1A
+    ogame->LoadSavegame( info->m_SlotNr, true );
+#else
+    gameMan->Read_Savegame( info->m_SlotNr );
+#endif
+  }
+
   QuickSave::QuickSave() {
     SetSaveSlotAndNr();
   }

--- a/zUtilities/QuickSave.h
+++ b/zUtilities/QuickSave.h
@@ -78,6 +78,7 @@ namespace GOTHIC_ENGINE {
     void EndSaveLoad();
     bool IsBusy();
     void Loop();
+    void MenuLoop();
     QuickSave();
   };
 

--- a/zUtilities/QuickSave.h
+++ b/zUtilities/QuickSave.h
@@ -54,8 +54,6 @@ namespace GOTHIC_ENGINE {
   class QuickSave {
   private:
     bool disabledStatus = false;
-    bool keepClosingMenus = false;
-    bool keyQuickLoadPressed = false;
 
     int iLastSaveSlot;
     int iLastSaveNumber;
@@ -66,7 +64,7 @@ namespace GOTHIC_ENGINE {
     void CheckSave();
     void CheckLoad();
     void StartSaveLoad();
-    void CloseMenuIfNotMain();
+    void LoadFromMainMenu() const;
 
   public:
     enum QuickSaveMode {
@@ -75,6 +73,7 @@ namespace GOTHIC_ENGINE {
       Alternative
     };
 
+    static bool KeepClosingMenus;
     bool saveEnd = false;
     bool isSaving = false;
     bool isLoading = false;

--- a/zUtilities/QuickSave.h
+++ b/zUtilities/QuickSave.h
@@ -54,6 +54,8 @@ namespace GOTHIC_ENGINE {
   class QuickSave {
   private:
     bool disabledStatus = false;
+    bool keepClosingMenus = false;
+    bool keyQuickLoadPressed = false;
 
     int iLastSaveSlot;
     int iLastSaveNumber;
@@ -64,6 +66,7 @@ namespace GOTHIC_ENGINE {
     void CheckSave();
     void CheckLoad();
     void StartSaveLoad();
+    void CloseMenuIfNotMain();
 
   public:
     enum QuickSaveMode {

--- a/zUtilities/ZenGin/Gothic_UserAPI/zCMenu.inl
+++ b/zUtilities/ZenGin/Gothic_UserAPI/zCMenu.inl
@@ -3,3 +3,5 @@
 // User API for zCMenu
 // Add your methods here
 
+void HandleFrame_Union(int);
+int Run_Union();


### PR DESCRIPTION
Added ability to load game straight from main menu (after game is launched).

One downside effect of this feature might be that previous menu window will still be visible after game is loaded when `Options::KeyQuickLoad` is tapped when `Options` menu is active or other nested menus.
This could be workaround by checking `if( menu->name != "MENU_MAIN" ) return;`.

I am looking for another solution to close all active menus then load game.
I tried something like:
```cpp
for (int i = zCMenu::activeList.GetNum()-1; i > 0; i--)
{
    auto item = zCMenu::activeList[i];
    item->HandleEvent(KEY_ESCAPE);
}
```
or use `ForceSelAction` with `BACK` option on first item in menu, but no positive outcome.
`zCMenu::GetActive()` is also not works it is not updating right after menu is closed.