### PR TITLE
Hold down `KeyTimeMultiplier` for additional `BoostTimeMultiplierFactor`

### DIFF
--- a/zUtilities/Options.h
+++ b/zUtilities/Options.h
@@ -59,6 +59,8 @@ namespace GOTHIC_ENGINE {
       zoptions->AddTrivia( PLUGIN_NAME, "UseTimeMultiplier", "... enables (1) or disables (0) time speed multiplier" );
       zoptions->AddTrivia( PLUGIN_NAME, "KeyTimeMultiplier", "... key for cycling time speed" );
       zoptions->AddTrivia( PLUGIN_NAME, "TimeMultipliers", "... defines time multipliers" );
+      zoptions->AddTrivia( PLUGIN_NAME, "BoostTimeMultiplierKeyDetectMilliseconds", "... time (in milliseconds) that need to pass to detect if 'KeyTimeMultiplier' is toggled to set 'BoostTimeMultiplierFactor' as actual time factor" );
+      zoptions->AddTrivia( PLUGIN_NAME, "BoostTimeMultiplierFactor", "... defines time multiplayer when 'KeyTimeMultiplier' is toggled (could be lower or higher than 'TimeMultipliers')" );
 
       zoptions->AddTrivia( PLUGIN_NAME, "QuickSaveMode", "... specifies QuickSave mode, (0) - 'Disabled', (1) - 'Standard', (2) - 'Alternative'" + nline + "... QuickSave with [F10] and QuickLoad with [F12]" );
       zoptions->AddTrivia( PLUGIN_NAME, "KeyQuickSave", "... key for QuickSave" );

--- a/zUtilities/PlayerStatus.cpp
+++ b/zUtilities/PlayerStatus.cpp
@@ -273,7 +273,7 @@ namespace GOTHIC_ENGINE {
             // key was just pressed for the first time
             keyTimeMultiplierPressedStartTime = std::chrono::high_resolution_clock::now();
             keyTimeMultiplierPreviouslyPressed = true;
-            keyTimeMultiplierToggled = false;
+            keyTimeMultiplierIsPressed = false;
       }
       else {
         // key is still pressed
@@ -281,10 +281,10 @@ namespace GOTHIC_ENGINE {
         auto pressDuration = std::chrono::duration_cast<std::chrono::milliseconds>( currentTime - keyTimeMultiplierPressedStartTime ).count();
 
         if ( pressDuration >= Options::BoostTimeMultiplierKeyDetectMilliseconds )
-          keyTimeMultiplierToggled = true;
+          keyTimeMultiplierIsPressed = true;
 
-        if ( keyTimeMultiplierToggled ) {
-          // this means that key is toggled
+        if ( keyTimeMultiplierIsPressed ) {
+          // this means that key is still pressed and time for release has passed so time to change `factorMotion`
           if ( ztimer->factorMotion != Options::BoostTimeMultiplierFactor )
             ztimer->factorMotion = Options::BoostTimeMultiplierFactor;
         }
@@ -293,8 +293,8 @@ namespace GOTHIC_ENGINE {
     else {
       if ( keyTimeMultiplierPreviouslyPressed ) {
         // key was just released
-        if ( keyTimeMultiplierToggled ) {
-          // this means that key was toggled, but released now
+        if ( keyTimeMultiplierIsPressed ) {
+          // this means that key was pressed, but released now
           if ( ztimer->factorMotion != 1.0f ) ztimer->factorMotion = 1.0f;
         }
         else {
@@ -302,7 +302,7 @@ namespace GOTHIC_ENGINE {
           auto pressDuration = std::chrono::duration_cast<std::chrono::milliseconds>( endTime - keyTimeMultiplierPressedStartTime ).count();
 
           if ( pressDuration < Options::BoostTimeMultiplierKeyDetectMilliseconds ) {
-            // key was pressed once;
+            // key was pressed and released within time window
             multiplierIndex++;
             if ( multiplierIndex < 0 || multiplierIndex >= Options::TimeMultipliers.GetNum() )
               multiplierIndex = 0;

--- a/zUtilities/PlayerStatus.h
+++ b/zUtilities/PlayerStatus.h
@@ -7,6 +7,8 @@ namespace GOTHIC_ENGINE {
     int KeyTimeMultiplier;
     Array<float> TimeMultipliers;
     int SaveReminder;
+    int BoostTimeMultiplierKeyDetectMilliseconds;
+    float BoostTimeMultiplierFactor;
 
     void PlayerStatus() {
       ShowGameTime = zoptions->ReadBool( PLUGIN_NAME, "ShowGameTime", false );
@@ -24,6 +26,9 @@ namespace GOTHIC_ENGINE {
       for ( int i = 0; i < MulStrings.GetNum(); i++ )
         TimeMultipliers.Insert( MulStrings[i].Shrink().ToReal32() );
 
+      BoostTimeMultiplierKeyDetectMilliseconds = zoptions->ReadInt(PLUGIN_NAME, "BoostTimeMultiplierKeyDetectMilliseconds", 250);
+      BoostTimeMultiplierFactor = zoptions->ReadReal(PLUGIN_NAME, "BoostTimeMultiplierFactor", 10.0f);
+
       SaveReminder = zoptions->ReadInt(PLUGIN_NAME, "SaveReminder", 5);
     }
   }
@@ -35,7 +40,10 @@ namespace GOTHIC_ENGINE {
     StatusBar* swimBar;
     int multiplierIndex = 0;
     int infoIcons = 0;
+    bool keyTimeMultiplierPreviouslyPressed = false;
+    bool keyTimeMultiplierToggled = false;
     std::chrono::high_resolution_clock::time_point lastSaveTime;
+    std::chrono::high_resolution_clock::time_point keyTimeMultiplierPressedStartTime;
 
     void ShowGameTime();
     void ShowMunitionAmount();

--- a/zUtilities/PlayerStatus.h
+++ b/zUtilities/PlayerStatus.h
@@ -41,7 +41,7 @@ namespace GOTHIC_ENGINE {
     int multiplierIndex = 0;
     int infoIcons = 0;
     bool keyTimeMultiplierPreviouslyPressed = false;
-    bool keyTimeMultiplierToggled = false;
+    bool keyTimeMultiplierIsPressed = false;
     std::chrono::high_resolution_clock::time_point lastSaveTime;
     std::chrono::high_resolution_clock::time_point keyTimeMultiplierPressedStartTime;
 


### PR DESCRIPTION
`KeyTimeMultiplier` still behaves same as before.
Just added new ability to hold down `KeyTimeMultiplier` button to set `ztimer->factorMotion` to other value than `TimeMultipliers` array.
This feature could be used for example if you need to quickly for a short time boost your time multiplier x10 or even slow it down to 0.5 (customizable by `BoostTimeMultiplierFactor`).

Added option `BoostTimeMultiplierKeyDetectMilliseconds` to configure how much time has to pass to detect if key is held down (pushed down).

I did not add option to disable it. This feature depends only on `UseTimeMultiplier`. If it's enabled then player decide to single press to toggle factor or hold down key to toggle factor until key is pressed then back to previous factor.