### PR TITLE
add AutoLoad

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a plugin with a set of many quality-of-life and utility features made fo
   - This feature can be disabled in `gothic.ini` with `QuickSaveMode` option.
   - Change `QuickSaveMode` option for different style or disable: `0` - _Disabled_, `1` - _Standard_, `2` - _Alternative_.
   - Game can also be quick loaded from main menu.
+  - Last save can be also automatically loaded on game launch with `EnableAutoLoad` option (default: `0` - Disabled, `1` - Enabled).
 
 - Changes name color of focused npcs, containers, doors and items.
 

--- a/zUtilities/Options.h
+++ b/zUtilities/Options.h
@@ -63,6 +63,7 @@ namespace GOTHIC_ENGINE {
       zoptions->AddTrivia( PLUGIN_NAME, "TimeMultipliers", "... defines time multipliers" );
 
       zoptions->AddTrivia( PLUGIN_NAME, "QuickSaveMode", "... specifies QuickSave mode, (0) - 'Disabled', (1) - 'Standard', (2) - 'Alternative'" + nline + "... QuickSave with [F10] and QuickLoad with [F12]" );
+      zoptions->AddTrivia( PLUGIN_NAME, "EnableAutoLoad", "... enables (1) or disables (0) loading last save after game launch" );
       zoptions->AddTrivia( PLUGIN_NAME, "KeyQuickSave", "... key for QuickSave" );
       zoptions->AddTrivia( PLUGIN_NAME, "KeyQuickLoad", "... key for QuickLoad" );
       zoptions->AddTrivia( PLUGIN_NAME, "MinSaveSlot", "... defines min range of used save slots" );

--- a/zUtilities/Plugin.cpp
+++ b/zUtilities/Plugin.cpp
@@ -1,6 +1,5 @@
 // This file added in headers queue
 // File: "Sources.h"
-#include "resource.h"
 
 namespace GOTHIC_ENGINE {
   void Game_Entry() {
@@ -11,6 +10,7 @@ namespace GOTHIC_ENGINE {
     Options::AddTrivias();
     RegisterCommands();
     quickSave = new QuickSave();
+    std::thread([=]() { quickSave->LoadFromMainMenuOnGameInit(); }).detach();
   }
 
   void Game_Exit() {

--- a/zUtilities/QuickSave.cpp
+++ b/zUtilities/QuickSave.cpp
@@ -1,6 +1,8 @@
 // Supported with union (c) 2020 Union team
 // Union SOURCE file
 
+#include <thread>
+
 namespace GOTHIC_ENGINE {
   bool QuickSave::KeepClosingMenus = false;
 
@@ -246,6 +248,14 @@ namespace GOTHIC_ENGINE {
 
     QuickSave::KeepClosingMenus = true;
     zoptions->WriteString( "internal", "menuAction", "SAVEGAME_LOAD", false );
+  }
+
+  void QuickSave::LoadFromMainMenuOnGameInit() {
+   if (!Options::EnableAutoLoad) return;
+
+   std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+   LoadFromMainMenu();
   }
 
   void QuickSave::StartSaveLoad() {

--- a/zUtilities/QuickSave.h
+++ b/zUtilities/QuickSave.h
@@ -3,11 +3,12 @@
 
 namespace GOTHIC_ENGINE {
   namespace Options {
-    int QuickSaveMode, UseBinarySave, KeyQuickSave, KeyQuickLoad, MinSaveSlot, MaxSaveSlot;
+    int QuickSaveMode, EnableAutoLoad, UseBinarySave, KeyQuickSave, KeyQuickLoad, MinSaveSlot, MaxSaveSlot;
     string CantSave, CantLoad, NoSave, SaveName;
 
     void QuickSave() {
       QuickSaveMode = zoptions->ReadInt( PLUGIN_NAME, "QuickSaveMode", 1 );
+      EnableAutoLoad = zoptions->ReadInt( PLUGIN_NAME, "EnableAutoLoad", 0 );
 
       KeyQuickSave = GetEmulationKeyCode( zoptions->ReadString( PLUGIN_NAME, "KeyQuickSave", "KEY_F10" ) );
       KeyQuickLoad = GetEmulationKeyCode( zoptions->ReadString( PLUGIN_NAME, "KeyQuickLoad", "KEY_F12" ) );
@@ -81,6 +82,7 @@ namespace GOTHIC_ENGINE {
     bool IsBusy();
     void Loop();
     void MenuLoop();
+    void LoadFromMainMenuOnGameInit();
     QuickSave();
   };
 


### PR DESCRIPTION
Adds a new option: `EnableAutoLoad` (disabled by default). When enabled, loads the last save after game launch. [Showcase](https://www.youtube.com/watch?v=-bAdoqegqh0).

Some games already have this feature thanks to mods (i.e. Morrowind), so why not add it to Gothic. It's really convenient for testing when you need to restart the game multiple times a day, especially when experimenting with different mods.

Cpp is not exactly my area of expertise, so feel free to correct it if you see any potential footguns. I added a 200 ms delay, otherwise it throws access violation. Admittedly, not the cleanest solution, but it works!